### PR TITLE
Fixed the PORT for mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start-win": "set PORT=3001 && react-scripts start",
-    "start": "export PORT=3001  react-scripts start",
+    "start": "PORT=3001  react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
Jan added "export PORT=3001" in package.json for mac computers. It didn't work with "export" in there. I removed "export" and it runs now. 